### PR TITLE
add conditional compilation for SGoap 

### DIFF
--- a/Integrations/SGoap/Actions/AttackAction.cs
+++ b/Integrations/SGoap/Actions/AttackAction.cs
@@ -1,3 +1,4 @@
+#if SGOAP
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
@@ -57,3 +58,4 @@ namespace DoubTech.TPSCharacterController.SGoap.Actions
         }
     }
 }
+#endif

--- a/Integrations/SGoap/Actions/FollowTarget.cs
+++ b/Integrations/SGoap/Actions/FollowTarget.cs
@@ -1,3 +1,4 @@
+#if SGOAP
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
@@ -35,3 +36,4 @@ namespace DoubTech.TPSCharacterController.SGoap.Actions
         }
     }
 }
+#endif

--- a/Integrations/SGoap/Demo/Scripts/Actions/FindTarget.cs
+++ b/Integrations/SGoap/Demo/Scripts/Actions/FindTarget.cs
@@ -1,3 +1,4 @@
+#if SGOAP
 using System;
 using UnityEngine;
 using System.Collections;
@@ -125,3 +126,4 @@ namespace DoubTech.TPSCharacterController.SGoap.Actions
         }
     }
 }
+#endif


### PR DESCRIPTION
Currently compilation fails if SGoap is not installed. Since not everyone owns SGoap this can be a problem. This adds scripting defines which works for those without SGoap. However, SGoap doesn't provide the define symbol so it needs to be added manually to enable it.